### PR TITLE
fix: unify footer labels and localize mood display to Japanese

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -19,11 +19,30 @@ class Post < ApplicationRecord
     その他
   ].freeze
 
-  # 気分：既存のまま（positive / neutral / negative）
+  # 気分
   enum :mood, { positive: 0, neutral: 1, negative: 2 }, prefix: true
 
-  # 公開範囲：private / public（既存のまま）
   enum :visibility, { private: 0, public: 1 }, prefix: true
+
+  # ▼ 表示用ラベル（UIで使う） ▼
+  MOOD_LABELS = {
+    "positive" => "ポジティブ",
+    "neutral"  => "ふつう",
+    "negative" => "ネガティブ"
+  }.freeze
+
+  def mood_label
+    MOOD_LABELS[mood] || mood.to_s
+  end
+
+  VISIBILITY_LABELS = {
+    "private" => "プライベート",
+    "public"  => "公開"
+  }.freeze
+
+  def visibility_label
+    VISIBILITY_LABELS[visibility] || visibility.to_s
+  end
 
   # ▼ バディ投稿MVP（#284）向け：最低限のバリデーション ▼
   validates :posted_at, presence: true

--- a/app/views/buddy_talks/_composer.html.erb
+++ b/app/views/buddy_talks/_composer.html.erb
@@ -1,5 +1,5 @@
 <div class="fixed left-0 right-0 bottom-[var(--bottom-nav-h)] z-40" style="--composer-h: 220px;">
-  <div class="px-4 sm:px-6 pb-4">
+  <div class="px-4 sm:px-6 pb-0">
     <div class="bg-[#FFF6E5]/95 backdrop-blur border border-amber-100 shadow-lg rounded-3xl p-4 sm:p-5">
       <%= form_with url: reply_buddy_talk_path(buddy_talk),
             method: :post,
@@ -21,19 +21,19 @@
         </div>
       <% end %>
 
-      <div class="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2">
-        <%= button_to "バディと一緒にもう少し振り返る",
+      <div class="mt-3 flex gap-2">
+        <%= button_to "一緒に振り返る",
               deep_dive_buddy_talk_path(buddy_talk),
               method: :post,
               form: { data: { turbo: true, turbo_submits_with: "生成中…" } },
-              class: "rounded-2xl px-4 py-3 text-sm font-semibold
+              class: "flex-1 rounded-2xl px-3 py-2 text-sm font-semibold whitespace-nowrap
                       bg-white border border-amber-200 text-amber-900 hover:bg-amber-50 transition" %>
 
-        <%= button_to "バディにまとめをお願いする",
+        <%= button_to "やさしくまとめる",
               praise_summary_buddy_talk_path(buddy_talk),
               method: :post,
               form: { data: { turbo: true, turbo_submits_with: "まとめ中…" } },
-              class: "rounded-2xl px-4 py-3 text-sm font-semibold
+              class: "flex-1 rounded-2xl px-3 py-2 text-sm font-semibold whitespace-nowrap
                       bg-amber-100 border border-amber-200 text-slate-800 hover:bg-amber-200 transition" %>
       </div>
     </div>

--- a/app/views/buddy_talks/_meta_readonly.html.erb
+++ b/app/views/buddy_talks/_meta_readonly.html.erb
@@ -1,28 +1,31 @@
+<% record = buddy_talk.respond_to?(:post) ? buddy_talk.post : buddy_talk %>
+
 <div class="space-y-3">
   <div class="bg-white rounded-3xl border border-amber-100 shadow-sm p-4 space-y-4">
     <div class="flex items-start justify-between gap-3">
       <div>
         <p class="text-xs text-slate-500">日付</p>
         <p class="font-semibold text-slate-800">
-          <%= buddy_talk.posted_at&.strftime("%Y/%m/%d %H:%M") %>
+          <% datetime = record.posted_at || record.created_at %>
+          <%= l datetime, format: :short %>
         </p>
       </div>
 
       <div class="flex-1">
         <p class="text-xs text-slate-500">タイトル</p>
         <p class="font-semibold text-slate-800">
-          <%= buddy_talk.title.presence || "（未入力）" %>
+          <%= record.title.presence || "（未入力）" %>
         </p>
       </div>
     </div>
   </div>
 
-  <% tags = buddy_talk.tags_text.to_s.split(",").map(&:strip).reject(&:blank?) %>
+  <% tags = record.tags_text.to_s.split(",").map(&:strip).reject(&:blank?) %>
 
   <div class="flex flex-wrap items-center gap-2 px-2">
     <span class="text-xs text-slate-500 mr-1">気分：</span>
     <span class="px-3 py-1 rounded-full bg-amber-50 text-amber-800 text-xs font-semibold border border-amber-100">
-      <%= buddy_talk.mood_i18n rescue buddy_talk.mood %>
+      <%= record.respond_to?(:mood_label) ? record.mood_label : (record.mood_i18n rescue record.mood) %>
     </span>
 
     <% if tags.any? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,13 +38,17 @@
     </style>
   </head>
 
-  <%# ここが重要：
-      --bottom-nav-h : ボトムナビの高さ（既定 80px）
-      --composer-h   : buddy_talk composer の高さ（既定 0px / 表示時に上書き）
+  <%# 重要：
+      --bottom-nav-h : ボトムナビ想定の高さ（mainの下余白用）
+      --composer-h   : buddy_talk composer の高さ（buddy_talk側で上書き）
   %>
   <body
     class="min-h-screen flex flex-col bg-[#FFF6E5]"
-    style="--bottom-nav-h: 80px; --composer-h: 0px;"
+    style="
+      --bottom-nav-h: 72px;
+      --composer-h: 0px;
+      <%= yield(:body_style) if content_for?(:body_style) %>
+    "
   >
     <header class="sticky top-0 z-40 bg-white/90 backdrop-blur shadow-sm">
       <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
@@ -93,7 +97,7 @@
 
     <%# main の padding-bottom を「ボトムナビ + composer」ぶん確保（被り防止） %>
     <main
-      class="flex-1 pt-2"
+      class="flex-1 pt-2 bg-[#FFF6E5]"
       style="padding-bottom: calc(var(--bottom-nav-h) + var(--composer-h) + 24px);"
     >
       <div class="max-w-5xl mx-auto px-4 py-8">
@@ -102,12 +106,7 @@
     </main>
 
     <% if (partial = current_bottom_nav_partial).present? %>
-      <nav
-        style="position: fixed; left: 0; right: 0; bottom: 0; z-index: 30; height: var(--bottom-nav-h);"
-        class="bg-white/95 border-t border-slate-200"
-      >
-        <%= render "shared/nav/#{partial}" %>
-      </nav>
+      <%= render "shared/nav/#{partial}" %>
     <% end %>
 
     <div id="ga-tracker" data-controller="ga"></div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -55,17 +55,20 @@
             <%= post.title.presence || "（無題）" %>
           </div>
 
-          <!-- タグ -->
-          <% tags = post.tags_text.to_s.split(",").map(&:strip).reject(&:blank?) %>
-          <% if tags.any? %>
-            <div class="mt-2 flex flex-wrap gap-2 text-xs">
-              <% tags.each do |tag| %>
-                <span class="inline-flex items-center px-2.5 py-1 rounded-full bg-slate-50 text-slate-700 border border-slate-200">
-                  #<%= tag %>
-                </span>
-              <% end %>
-            </div>
-          <% end %>
+          <!-- 気分 + タグ -->
+          <div class="mt-2 flex flex-wrap items-center gap-2 text-xs">
+            <%# 気分（英語にならない） %>
+            <span class="inline-flex items-center px-2.5 py-1 rounded-full bg-amber-50 text-amber-800 border border-amber-100">
+              気分：<%= post.mood_label %>
+            </span>
+
+            <% tags = post.tags_text.to_s.split(",").map(&:strip).reject(&:blank?) %>
+            <% tags.each do |tag| %>
+              <span class="inline-flex items-center px-2.5 py-1 rounded-full bg-slate-50 text-slate-700 border border-slate-200">
+                #<%= tag %>
+              </span>
+            <% end %>
+          </div>
 
           <!-- アクション -->
           <div class="mt-4 flex items-center justify-between">

--- a/app/views/shared/nav/_main.html.erb
+++ b/app/views/shared/nav/_main.html.erb
@@ -1,8 +1,8 @@
 <nav
-  class="border-t bg-white/95 backdrop-blur"
-  style="position: fixed; left: 0; right: 0; bottom: 0; z-index: 30;"
+  class="fixed left-0 right-0 bottom-0 z-30 border-t border-slate-200 bg-white"
+  style="padding-bottom: env(safe-area-inset-bottom);"
 >
-  <div class="mx-auto w-full max-w-screen-md px-3 pt-2 pb-[calc(env(safe-area-inset-bottom)+0.5rem)]">
+  <div class="mx-auto w-full max-w-screen-md px-3 pt-1 pb-2">
     <ul
       class="grid gap-3 justify-items-center text-[11px] w-full"
       style="grid-template-columns: repeat(6, minmax(0, 1fr));"
@@ -10,7 +10,7 @@
       <li>
         <%= link_to root_path, class: "flex flex-col items-center gap-1" do %>
           <%= image_tag "/bottom_nav/home.png", class: "w-8 h-8", alt: "マイルーム" %>
-          <span class="font-semibold">マイルーム</span>
+          <span class="font-semibold">ホーム</span>
         <% end %>
       </li>
 
@@ -31,7 +31,7 @@
       <li>
         <%= link_to buddy_talk_path, class: "flex flex-col items-center gap-1" do %>
           <%= image_tag "/bottom_nav/buddy_talk.png", class: "w-8 h-8", alt: "バディと話す" %>
-          <span class="font-semibold">バディと話す</span>
+          <span class="font-semibold">話す</span>
         <% end %>
       </li>
 

--- a/app/views/shared/nav/_signed_in.html.erb
+++ b/app/views/shared/nav/_signed_in.html.erb
@@ -10,14 +10,14 @@
       <li>
         <%= link_to root_path, class: "flex flex-col items-center gap-1" do %>
           <%= image_tag "/bottom_nav/home.png", class: "w-8 h-8", alt: "マイルーム" %>
-          <span class="font-semibold">マイルーム</span>
+          <span class="font-semibold">ホーム</span>
         <% end %>
       </li>
 
       <li>
         <%= link_to buddy_talk_path, class: "flex flex-col items-center gap-1" do %>
           <%= image_tag "/bottom_nav/buddy_talk.png", class: "w-8 h-8", alt: "バディと話す" %>
-          <span class="font-semibold">バディと話す</span>
+          <span class="font-semibold">話す</span>
         <% end %>
       </li>
 


### PR DESCRIPTION
## 概要
以下のUI表示まわりの不具合を修正しました。

## 修正内容
- フッターナビの「マイルーム」表記を「ホーム」に統一
- バディと話す画面で、気分（mood）が英語表示（positive / neutral / negative）になっていた問題を修正し、日本語表示に統一
- 投稿一覧・バディ会話画面間での表示差異を解消

## 対応背景
- 一覧画面では日本語表示されていた一方、バディ会話画面では英語表記が残っており、UIの一貫性が崩れていたため
- フッター文言変更が反映されていない原因を切り分け、使用されているpartialを修正

## 動作確認
- ローカル環境にて以下画面を確認
  - マイルーム（ホーム）
  - バディと話す
  - 投稿一覧
- 各画面でフッター文言・気分表示が正しく日本語になっていることを確認済み
