### PR TITLE
分析ページに強みTOP5の表示枠を追加

### DIFF
--- a/app/controllers/analyses_controller.rb
+++ b/app/controllers/analyses_controller.rb
@@ -1,0 +1,8 @@
+class AnalysesController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    analyzer = StrengthAnalyzer.new(current_user)
+    @top_strengths = analyzer.top_strengths
+  end
+end

--- a/app/lib/strength_dimension.rb
+++ b/app/lib/strength_dimension.rb
@@ -1,0 +1,13 @@
+module StrengthDimension
+  # 将来種類を増やすならここに追加するだけでOK
+  DEFINITIONS = {
+    empathy:     { label: "共感力" },
+    persistence:{ label: "継続" },
+    challenge:  { label: "挑戦" },
+    analysis:   { label: "分析" },
+    expression: { label: "表現" }
+  }.freeze
+
+  def self.keys = DEFINITIONS.keys
+  def self.labels = DEFINITIONS.values.map { _1[:label] }
+end

--- a/app/models/strength_dimension.rb
+++ b/app/models/strength_dimension.rb
@@ -1,0 +1,13 @@
+module StrengthDimension
+  # key はDB保存/集計用（将来軸を増やしても壊れにくい）
+  DEFINITIONS = {
+    empathy:      { label: "共感力" },
+    persistence:  { label: "継続" },
+    challenge:    { label: "挑戦" },
+    analysis:     { label: "分析" },
+    expression:   { label: "表現" }
+  }.freeze
+
+  def self.keys = DEFINITIONS.keys
+  def self.labels = DEFINITIONS.values.map { _1[:label] }
+end

--- a/app/services/strength_analyzer.rb
+++ b/app/services/strength_analyzer.rb
@@ -1,0 +1,38 @@
+class StrengthAnalyzer
+  TOP_N = 5
+
+  StrengthItem = Struct.new(:label, :description, :evidence, keyword_init: true)
+
+  def initialize(user)
+    @user = user
+  end
+
+  # 表示用：StrongItem の配列
+  def top_strengths
+    # いまは仮データ（段階1でAI算出に置き換える）
+    StrengthDimension.labels.first(TOP_N).map do |label|
+      StrengthItem.new(
+        label: label,
+        description: default_description(label),
+        evidence: default_evidence # 会話の引用が入ると「評価」感が下がる
+      )
+    end
+  end
+
+  private
+
+  def default_description(label)
+    case label
+    when "共感力" then "相手の気持ちを汲み取り、安心できる空気を作りやすい"
+    when "継続"   then "小さく積み上げて、形にしていくのが得意"
+    when "挑戦"   then "新しいことにも一歩ずつ試せる"
+    when "分析"   then "状況を整理して、次にやることを決められる"
+    when "表現"   then "気持ちや考えを言葉にして伝えられる"
+    else "あなたらしさが出やすいポイント"
+    end
+  end
+
+  def default_evidence
+    "（会話の中で印象的だった一文が入ります）"
+  end
+end

--- a/app/views/analyses/_strength_radar.html.erb
+++ b/app/views/analyses/_strength_radar.html.erb
@@ -1,0 +1,26 @@
+<div class="border border-slate-400/60 bg-[#FBF6E3] p-4">
+  <p class="font-semibold mb-3">&lt;強み傾向&gt;</p>
+
+  <p class="text-sm text-slate-600 mb-4">
+    最近の会話から、あなたらしさが出やすいポイントをまとめました。
+  </p>
+
+  <ol class="space-y-3">
+    <% @top_strengths.each_with_index do |item, idx| %>
+      <li class="bg-white/80 border border-slate-200 rounded-xl p-3">
+        <div class="flex items-center gap-2">
+          <span class="inline-flex items-center justify-center w-6 h-6 rounded-full bg-amber-100 text-slate-700 text-xs font-bold">
+            <%= idx + 1 %>
+          </span>
+          <p class="font-semibold text-slate-800"><%= item.label %></p>
+        </div>
+
+        <p class="text-sm text-slate-700 mt-2"><%= item.description %></p>
+
+        <p class="text-xs text-slate-500 mt-2">
+          例：<%= item.evidence %>
+        </p>
+      </li>
+    <% end %>
+  </ol>
+</div>

--- a/app/views/analyses/_strength_top5.html.erb
+++ b/app/views/analyses/_strength_top5.html.erb
@@ -1,0 +1,26 @@
+<div class="border border-slate-400/60 bg-[#FBF6E3] p-4">
+  <p class="font-semibold mb-3">&lt;強み傾向&gt;</p>
+
+  <p class="text-sm text-slate-600 mb-4">
+    最近の会話から、あなたらしさが出やすいポイントをまとめました。
+  </p>
+
+  <ol class="space-y-3">
+    <% @top_strengths.each_with_index do |item, idx| %>
+      <li class="bg-white/80 border border-slate-200 rounded-xl p-3">
+        <div class="flex items-center gap-2">
+          <span class="inline-flex items-center justify-center w-6 h-6 rounded-full bg-amber-100 text-slate-700 text-xs font-bold">
+            <%= idx + 1 %>
+          </span>
+          <p class="font-semibold text-slate-800"><%= item.label %></p>
+        </div>
+
+        <p class="text-sm text-slate-700 mt-2"><%= item.description %></p>
+
+        <p class="text-xs text-slate-500 mt-2">
+          例：<%= item.evidence %>
+        </p>
+      </li>
+    <% end %>
+  </ol>
+</div>

--- a/app/views/analyses/show.html.erb
+++ b/app/views/analyses/show.html.erb
@@ -1,0 +1,3 @@
+<h1 class="text-xl font-bold mb-4">自己分析らぼ</h1>
+
+<%= render "strength_top5" %>

--- a/app/views/shared/nav/_signed_in.html.erb
+++ b/app/views/shared/nav/_signed_in.html.erb
@@ -43,7 +43,7 @@
       </li>
 
       <li>
-        <%= link_to others_path, class: "flex flex-col items-center gap-1" do %>
+        <%= link_to analysis_path, class: "flex flex-col items-center gap-1" do %>
           <%= image_tag "/bottom_nav/insight.png", class: "w-8 h-8", alt: "分析" %>
           <span class="font-semibold">分析</span>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,4 +74,10 @@ Rails.application.routes.draw do
   resources :buddies, only: [:index] do
     post :select, on: :member
   end
+
+  # -------------------------------------------------------
+  # 分析
+  # -------------------------------------------------------
+  resource :analysis, only: [:show]
+
 end


### PR DESCRIPTION
## 概要
分析ページに「強みTOP5」を表示するための入れ物（UI）を追加しました。
バディ会話から算出した強みを、評価的に見せすぎない形で整理・表示することを目的としています。

## 対応内容
- /analysis ページを新規作成
- 強みTOP5を列挙形式で表示するUIを追加
- 既存のレーダーチャート試作コード（Chart.js / Stimulus）を整理・削除
- 不要なJS参照によるコンソールエラーを解消

## 確認方法
1. ログイン後、フッターの「分析」から分析ページへ遷移
2. 「強み傾向」セクションにTOP5が表示されることを確認
3. コンソールエラーが発生しないことを確認

## 補足
- 強みの算出ロジックは今後追加予定のため、今回は表示用の入れ物のみ実装しています