### PR TITLE
投稿のお気に入り機能を追加

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,0 +1,22 @@
+class FavoritesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_post
+
+  def create
+    current_user.favorites.create!(post: @post)
+    redirect_back fallback_location: posts_path, notice: "お気に入りに追加しました"
+  rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
+    redirect_back fallback_location: posts_path
+  end
+
+  def destroy
+    current_user.favorites.find_by!(post: @post).destroy!
+    redirect_back fallback_location: posts_path, notice: "お気に入りを解除しました"
+  end
+
+  private
+
+  def set_post
+    @post = current_user.posts.find(params[:post_id])
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -10,7 +10,7 @@ class PostsController < ApplicationController
 
     if params[:date].present?
       d = Date.parse(params[:date])
-      scope = scope.where(posted_at: d.beginning_of_day..d.end_of_day) # created_atよりposted_at推奨
+      scope = scope.where(posted_at: d.beginning_of_day..d.end_of_day)
     end
 
     if params[:category].present? && params[:category] != "all"
@@ -22,6 +22,9 @@ class PostsController < ApplicationController
     end
 
     @posts = scope.order(posted_at: :desc).page(params[:page])
+
+    post_ids = @posts.map(&:id)
+    @favorite_post_ids = current_user.favorites.where(post_id: post_ids).pluck(:post_id)
   end
 
   def show

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,6 @@
+class Favorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+
+  validates :user_id, uniqueness: { scope: :post_id }
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,9 @@
 class Post < ApplicationRecord
   belongs_to :user
-  has_many :ai_messages, dependent: :destroy
   has_many :buddy_messages, dependent: :destroy
+  has_many :favorites, dependent: :destroy
+  has_many :favorited_users, through: :favorites, source: :user
+  has_many :ai_messages, dependent: :destroy
   has_many :ai_logs, dependent: :destroy
 
   TAG_OPTIONS = %w[

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,8 @@ class User < ApplicationRecord
   # アソシエーション
   # -------------------------------------------------------
   has_many :posts, dependent: :destroy
+  has_many :favorites, dependent: :destroy
+  has_many :favorite_posts, through: :favorites, source: :post
   has_many :ai_messages, dependent: :destroy
   has_many :ai_message_feedbacks, dependent: :destroy
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -91,24 +91,45 @@
             </div>
 
             <!-- アクション（入れ子防止：カード全体リンクはしない） -->
-            <div class="mt-4 flex items-center justify-between gap-2">
-              <%= link_to "会話を開く",
+            <div class="mt-4 flex items-center gap-2">
+              <%= link_to "▶︎ 会話を開く",
                     buddy_talk_topic_path(post),
                     data: { turbo: false },
-                    class: "text-sm font-semibold text-amber-800 hover:underline" %>
+                    class: "shrink-0 text-sm font-semibold text-amber-800 hover:underline hover:bg-amber-50 px-1 py-1 rounded-md" %>
 
-              <div class="flex items-center gap-2">
+              <div class="ml-auto flex items-center gap-2 justify-end">
+                <% if user_signed_in? %>
+                  <% favorited = @favorite_post_ids.include?(post.id) %>
+
+                  <% if favorited %>
+                    <%= button_to "★ お気に入り",
+                      post_favorite_path(post),
+                      method: :delete,
+                      form: { class: "inline-block" },
+                      class: "inline-flex items-center justify-center rounded-full px-4 py-2 text-xs font-semibold
+                              border border-amber-200 bg-amber-50 text-slate-700 hover:bg-amber-50/70" %>
+                  <% else %>
+                    <%= button_to "☆ お気に入り",
+                      post_favorite_path(post),
+                      method: :post,
+                      form: { class: "inline-block" },
+                      class: "inline-flex items-center justify-center rounded-full px-4 py-2 text-xs font-semibold
+                              border border-slate-200 bg-white text-slate-700 hover:bg-slate-50" %>
+                  <% end %>
+                <% end %>
+
                 <%= link_to "編集",
                       edit_post_path(post),
                       data: { turbo_frame: "_top" },
                       class: "inline-flex items-center justify-center rounded-full px-4 py-2 text-xs font-semibold
                               border border-slate-200 bg-white text-slate-700 hover:bg-slate-50" %>
 
-              <%= button_to "削除",
-                    post_path(post),
-                    method: :delete,
-                    form: { data: { turbo_confirm: "本当にこの投稿を削除しますか？" } },
-                    class: "text-xs px-4 py-2 rounded-full border border-rose-300 text-rose-600 hover:bg-rose-50" %>
+                <%= button_to "削除",
+                      post_path(post),
+                      method: :delete,
+                      form: { class: "inline-block", data: { turbo_confirm: "本当にこの投稿を削除しますか？" } },
+                      class: "inline-flex items-center justify-center rounded-full px-4 py-2 text-xs font-semibold
+                              border border-rose-300 text-rose-600 hover:bg-rose-50" %>
               </div>
             </div>
           </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
   # -------------------------------------------------------
   resources :posts, only: [ :index, :edit, :update, :destroy ] do
     post :preview_ai, on: :member
+    resource :favorite, only: %i[create destroy]
   end
 
   # -------------------------------------------------------

--- a/db/migrate/20260209121729_create_favorites.rb
+++ b/db/migrate/20260209121729_create_favorites.rb
@@ -1,0 +1,12 @@
+class CreateFavorites < ActiveRecord::Migration[8.0]
+  def change
+    create_table :favorites do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :favorites, [:user_id, :post_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_08_095839) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_09_121729) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -96,6 +96,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_08_095839) do
     t.integer "position", null: false
     t.datetime "updated_at", null: false
     t.index ["position"], name: "index_diagnosis_questions_on_position", unique: true
+  end
+
+  create_table "favorites", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "post_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["post_id"], name: "index_favorites_on_post_id"
+    t.index ["user_id", "post_id"], name: "index_favorites_on_user_id_and_post_id", unique: true
+    t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
   create_table "posts", force: :cascade do |t|
@@ -267,6 +277,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_08_095839) do
   add_foreign_key "ai_messages", "users"
   add_foreign_key "buddy_messages", "posts", on_delete: :cascade
   add_foreign_key "buddy_messages", "users"
+  add_foreign_key "favorites", "posts"
+  add_foreign_key "favorites", "users"
   add_foreign_key "posts", "users"
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/test/fixtures/favorites.yml
+++ b/test/fixtures/favorites.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  post: one
+
+two:
+  user: two
+  post: two

--- a/test/models/favorite_test.rb
+++ b/test/models/favorite_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FavoriteTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 概要

投稿一覧から投稿を「お気に入り」登録/解除できる機能を追加しました。

# 内容

- 投稿に対するお気に入り（Favorite）を作成/削除できるように追加
- posts#index にお気に入りボタン（☆/★）を表示
- 一覧表示時に @favorite_post_ids をまとめて取得し、判定のN+1を回避
- ルーティングに resource :favorite（create/destroy）を追加

# 確認方法

- ログインして投稿一覧を開く
- 任意の投稿で「☆ お気に入り」を押す → 表示が「★ お気に入り」に変わる
- 「★ お気に入り」を押す → 解除され「☆ お気に入り」に戻る
- bin/rails routes | grep favorite でルーティングが存在することを確認

# 補足

ボタン配置（右寄せなど）のUI調整は別Issueで対応予定