### PR TITLE
Renderデプロイエラー修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,3 +78,9 @@ gem "ransack"
 gem "ruby-openai", "~> 8.3"
 
 gem "meta-tags"
+
+gem "image_processing", "~> 1.2"
+
+group :production do
+  gem "stackprof", require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,14 @@ GEM
       multipart-post (~> 2.0)
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-aarch64-linux-musl)
+    ffi (1.17.3-arm-linux-gnu)
+    ffi (1.17.3-arm-linux-musl)
+    ffi (1.17.3-arm64-darwin)
+    ffi (1.17.3-x86_64-darwin)
+    ffi (1.17.3-x86_64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-musl)
     fugit (1.12.1)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
@@ -138,6 +146,9 @@ GEM
       activesupport (>= 6.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    image_processing (1.14.0)
+      mini_magick (>= 4.9.5, < 6)
+      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (2.2.2)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -190,6 +201,8 @@ GEM
     matrix (0.4.3)
     meta-tags (2.22.2)
       actionpack (>= 6.0.0, < 8.2)
+    mini_magick (5.3.1)
+      logger
     mini_mime (1.1.5)
     minitest (5.27.0)
     msgpack (1.8.0)
@@ -347,6 +360,9 @@ GEM
       faraday (>= 1)
       faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.3.0)
+      ffi (~> 1.12)
+      logger
     rubyzip (3.2.2)
     securerandom (0.4.1)
     selenium-webdriver (4.39.0)
@@ -384,6 +400,7 @@ GEM
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
       ostruct
+    stackprof (0.2.27)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.2.0)
@@ -450,6 +467,7 @@ DEPENDENCIES
   debug
   devise (~> 4.9)
   devise-i18n
+  image_processing (~> 1.2)
   importmap-rails
   jbuilder
   kamal
@@ -469,6 +487,7 @@ DEPENDENCIES
   solid_cable
   solid_cache
   solid_queue
+  stackprof
   stimulus-rails
   tailwindcss-rails (~> 4.4)
   thruster


### PR DESCRIPTION
**## 概要
Render 環境でのデプロイ時に発生していたエラーを解消するため、
ActiveStorage が必要とする `image_processing` gem を追加しました。

## 背景
Render のログにて以下のエラーが発生していました。

```
Generating image variants require the image_processing gem.
Please add gem 'image_processing', '~> 1.2'
```

ActiveStorage による画像処理が有効になっているにも関わらず、
`image_processing` gem が Gemfile に含まれていなかったため、
アプリ起動時にエラーとなっていました。

## 変更内容
- `image_processing (~> 1.2)` を Gemfile に追加

## 影響範囲
- アプリの機能仕様に変更はありません
- Render 本番環境でのデプロイが正常に完了するようになります

## 確認事項
- Render のデプロイが成功すること
- アプリが正常に起動すること
