### PR TITLE
認証・オンボーディングのbefore_action整理と未定義callbackエラー修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,11 +7,8 @@ class ApplicationController < ActionController::Base
   # meta-tags（全ページ共通の初期値）
   before_action :set_default_meta_tags
 
-  # ログイン必須（public は除外）
-  before_action :authenticate_user!, unless: :public_controller?
-
-  # オンボーディング強制リダイレクト（Devise と public は除外）
-  before_action :redirect_to_onboarding_if_needed, unless: :public_controller?
+  # 未ログインの人が protected に来たら onboarding に送る（public は除外）
+  before_action :redirect_guest_to_onboarding, unless: :public_controller?
 
   helper_method :current_buddy, :bottom_nav_key
 
@@ -49,16 +46,12 @@ class ApplicationController < ActionController::Base
     %w[top onboardings diagnoses].include?(controller_name)
   end
 
-  def redirect_to_onboarding_if_needed
-    # Devise では絶対に動かさない
-    return if devise_controller?
+  # 未ログインはオンボへ（ログイン済みなら通常ページ）
+  def redirect_guest_to_onboarding
+    return if user_signed_in?
 
-    return unless user_signed_in?
-    return if current_user.onboarded?
-    return if controller_name == "onboardings"
-
-    # オンボ完了のきっかけになる画面は通す
-    return if controller_name.in?(%w[diagnoses buddies posts])
+    # 任意：ログイン後に元のページへ戻したいなら有効化
+    store_location_for(:user, request.fullpath) if request.get?
 
     redirect_to onboarding_path
   end

--- a/app/controllers/diagnoses_controller.rb
+++ b/app/controllers/diagnoses_controller.rb
@@ -1,8 +1,6 @@
 class DiagnosesController < ApplicationController
   before_action :set_bottom_nav
 
-  skip_before_action :authenticate_user!, only: [ :top, :questions, :result, :result_page, :share ]
-
   VALID_TYPES = %w[expressive driving amiable analytical].freeze
 
   def top

--- a/app/controllers/onboardings_controller.rb
+++ b/app/controllers/onboardings_controller.rb
@@ -1,6 +1,4 @@
 class OnboardingsController < ApplicationController
-  skip_before_action :authenticate_user!, only: [ :welcome, :about ]
-  skip_before_action :redirect_to_onboarding_if_needed, only: [ :welcome, :about, :complete ]
 
   def welcome; end
   def about; end

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,5 +1,4 @@
 class TopController < ApplicationController
-  skip_before_action :redirect_to_onboarding_if_needed
 
   def index
     redirect_to onboarding_path unless user_signed_in?

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,4 @@
 class Users::SessionsController < Devise::SessionsController
-  skip_before_action :redirect_to_onboarding_if_needed, only: [ :destroy ]
-
   protected
 
   def after_sign_out_path_for(_resource_or_scope)


### PR DESCRIPTION
## 概要

- skip_before_action :authenticate_user! を削除
- skip_before_action :redirect_to_onboarding_if_needed を削除
- 未定義callbackによるArgumentErrorを解消
- 認証・オンボーディング判定をApplicationControllerに一本化

## 背景

ApplicationController側のbefore_action構成を変更したことにより、
各Controllerに残っていた skip_before_action が未定義callbackとなりエラーが発生していたため整理。

## 変更内容

- DiagnosesController / OnboardingsController / TopController の skip_before_action 削除
- 認証フローを以下に統一

  - 未ログイン → public_controller? のみ閲覧可
  - ログイン済み → 通常ページ表示
  - オンボーディング強制遷移は廃止

## 動作確認

- 既存ユーザーで正常に表示される
- 新規登録後オンボに飛ばない
- 未ログイン時は制限ページにリダイレクトされる
- サインアウト時エラーが出ない
