### PR TITLE
認証・オンボーディング制御の整理と未ログイン挙動の修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,8 +7,11 @@ class ApplicationController < ActionController::Base
   # meta-tags（全ページ共通の初期値）
   before_action :set_default_meta_tags
 
-  # 未ログインの人が protected に来たら onboarding に送る（public は除外）
-  before_action :redirect_guest_to_onboarding, unless: :public_controller?
+  # ログイン必須（public は除外）
+  before_action :authenticate_user!, unless: :public_controller?
+
+  # 互換性のため “この名前” を残す（他controllerの skip_before_action が参照している）
+  before_action :redirect_to_onboarding_if_needed, unless: :public_controller?
 
   helper_method :current_buddy, :bottom_nav_key
 
@@ -41,17 +44,18 @@ class ApplicationController < ActionController::Base
   private
 
   # ログイン不要で見せる画面（+ Devise）
+  # ※「未ログインはオンボに飛ぶ」方針なので、ここは最小限にする
   def public_controller?
     return true if devise_controller?
     %w[top onboardings diagnoses].include?(controller_name)
   end
 
-  # 未ログインはオンボへ（ログイン済みなら通常ページ）
-  def redirect_guest_to_onboarding
+  # 未ログインだけオンボへ（ログイン済みは一切ブロックしない）
+  def redirect_to_onboarding_if_needed
+    return if devise_controller?
+    return if controller_name == "onboardings"
+    return if controller_name == "diagnoses"
     return if user_signed_in?
-
-    # 任意：ログイン後に元のページへ戻したいなら有効化
-    store_location_for(:user, request.fullpath) if request.get?
 
     redirect_to onboarding_path
   end

--- a/app/controllers/onboardings_controller.rb
+++ b/app/controllers/onboardings_controller.rb
@@ -1,5 +1,4 @@
 class OnboardingsController < ApplicationController
-
   def welcome; end
   def about; end
 

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,5 +1,4 @@
 class TopController < ApplicationController
-
   def index
     redirect_to onboarding_path unless user_signed_in?
   end


### PR DESCRIPTION
## 概要
認証およびオンボーディング制御の見直しを行いました。

## 背景
・before_actionの削除に伴い、skip_before_actionで未定義エラーが発生していた  
・未ログイン状態でも診断ページが利用できる設計であるにも関わらず、ログインが求められる状態になっていた  

## 修正内容
・redirect_to_onboarding_if_needed関連の不要なskipを削除  
・authenticate_user!のskip指定を修正  
・未ログイン時のアクセス制御を整理  

### 挙動
- 未ログイン  
  - 診断：閲覧可能  
  - 話す / 分析：オンボーディングへ遷移  
- ログイン済み：通常動作  

## 影響範囲
認証・オンボーディング制御周辺
