### PR TITLE
分析ページの本文色を黒寄りに統一（アクセントはオレンジ維持）

### DIFF
--- a/app/views/analytics/_strength_top5.html.erb
+++ b/app/views/analytics/_strength_top5.html.erb
@@ -4,16 +4,16 @@
 <% data_insufficient = !!local_assigns[:data_insufficient] %>
 
 <div class="border border-amber-100 bg-white p-4 rounded-2xl shadow-sm h-full">
-  <p class="font-semibold mb-3"><%= title %></p>
+  <p class="font-semibold text-slate-900 mb-3"><%= title %></p>
 
   <% if description.present? %>
-    <p class="text-sm text-amber-600 mb-4"><%= description %></p>
+    <p class="text-sm text-slate-600 mb-4"><%= description %></p>
   <% end %>
 
   <% if data_insufficient || items.empty? %>
     <div class="bg-white/70 border border-amber-200 rounded-xl p-4 text-sm text-slate-700">
-      <p class="font-semibold">データが不足しています</p>
-      <p class="text-xs text-amber-500 mt-1">（投稿が増えると、あなたらしさがもう少し見えやすくなります）</p>
+      <p class="font-semibold text-slate-900">データが不足しています</p>
+      <p class="text-xs text-slate-500 mt-1">（投稿が増えると、あなたらしさがもう少し見えやすくなります）</p>
     </div>
   <% else %>
     <ol class="space-y-3">
@@ -23,7 +23,7 @@
             <span class="inline-flex items-center justify-center w-6 h-6 rounded-full bg-amber-100 text-slate-800 text-xs font-bold">
               <%= idx + 1 %>
             </span>
-            <p class="font-semibold text-amber-900">
+            <p class="font-semibold text-slate-900">
               <%= item[:label] %>：<span class="font-semibold text-slate-700"><%= item[:short] %></span>
             </p>
           </div>

--- a/app/views/analytics/_suggestions.html.erb
+++ b/app/views/analytics/_suggestions.html.erb
@@ -1,7 +1,7 @@
 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
   <div class="border border-amber-400/60 bg-[#FBF6E3] p-4">
     <p class="font-semibold mb-2">あなたの良さを、そっと活かすヒント</p>
-    <ul class="list-disc pl-5 text-sm text-amber-700 space-y-1">
+    <ul class="list-disc pl-5 text-sm text-slate-700 space-y-1">
       <% Array(@strength_suggestions).each do |t| %>
         <li><%= t %></li>
       <% end %>
@@ -10,7 +10,7 @@
 
   <div class="border border-amber-400/60 bg-[#FBF6E3] p-4">
     <p class="font-semibold mb-2">ちょっとしんどい場面で、思い出してほしいこと</p>
-    <ul class="list-disc pl-5 text-sm text-amber-700 space-y-1">
+    <ul class="list-disc pl-5 text-sm text-slate-700 space-y-1">
       <% Array(@weakness_suggestions).each do |t| %>
         <li><%= t %></li>
       <% end %>

--- a/app/views/analytics/_tips_box.html.erb
+++ b/app/views/analytics/_tips_box.html.erb
@@ -9,7 +9,7 @@
 
 <div class="border border-amber-100 bg-white p-4 rounded-2xl shadow-sm h-full">
   <div class="flex items-center justify-between gap-3 mb-3">
-    <p class="font-bold"><%= title %></p>
+    <p class="font-bold text-slate-900"><%= title %></p>
 
     <% if maskable %>
       <% if show_tips %>
@@ -34,18 +34,18 @@
   </div>
 
   <% if maskable && !show_tips %>
-    <div class="bg-amber-50 border border-amber-200 rounded-xl p-4 text-sm text-amber-700">
-      <p class="font-bold">＊必要なときだけ開けば大丈夫です</p>
-      <p class="text-xs text-amber-500 mt-1">（今は閉じたままでOKです）</p>
+    <div class="bg-amber-50 border border-amber-200 rounded-xl p-4 text-sm text-slate-700">
+      <p class="font-bold text-slate-900">＊必要なときだけ開けば大丈夫です</p>
+      <p class="text-xs text-slate-500 mt-1">（今は閉じたままでOKです）</p>
     </div>
   <% else %>
     <% if tips.empty? %>
-      <div class="bg-amber-50 border border-amber-200 rounded-xl p-4 text-sm text-amber-700">
-        <p class="font-bold">データが不足しています</p>
-        <p class="text-xs text-amber-500 mt-1">（投稿が増えると、ヒントがより具体的になります）</p>
+      <div class="bg-amber-50 border border-amber-200 rounded-xl p-4 text-sm text-slate-700">
+        <p class="font-bold text-slate-900">データが不足しています</p>
+        <p class="text-xs text-slate-500 mt-1">（投稿が増えると、ヒントがより具体的になります）</p>
       </div>
     <% else %>
-      <ul class="list-disc pl-5 text-sm text-amber-700 space-y-2">
+      <ul class="list-disc pl-5 text-sm text-slate-700 space-y-2">
         <% tips.each do |t| %>
           <li><%= t %></li>
         <% end %>

--- a/app/views/analytics/_weakness_top5.html.erb
+++ b/app/views/analytics/_weakness_top5.html.erb
@@ -8,7 +8,7 @@
 
 <div class="border border-amber-100 bg-white p-4 rounded-2xl shadow-sm h-full">
   <div class="flex items-center justify-between gap-3 mb-3">
-    <p class="font-bold"><%= title %></p>
+    <p class="font-bold text-slate-900"><%= title %></p>
 
     <% if show_items %>
       <%= link_to "▲ 閉じる",
@@ -31,22 +31,21 @@
   </div>
 
   <% if !show_items %>
-    <!-- 閉じている時は、内容も説明も一切出さない -->
-    <div class="bg-amber-50 border border-amber-200 rounded-xl p-4 text-sm text-amber-700">
-      <p class="font-bold">＊しんどいときや、無理を減らしたいときにだけ開いてください</p>
-      <p class="text-xs text-amber-500 mt-1">（元気なときは閉じたままで大丈夫です）</p>
+    <div class="bg-amber-50 border border-amber-200 rounded-xl p-4 text-sm text-slate-700">
+      <p class="font-bold text-slate-900">＊しんどいときや、無理を減らしたいときにだけ開いてください</p>
+      <p class="text-xs text-slate-500 mt-1">（元気なときは閉じたままで大丈夫です）</p>
     </div>
   <% else %>
     <% if description.present? %>
-      <p class="text-sm text-amber-600 mb-4"><%= description %></p>
+      <p class="text-sm text-slate-600 mb-4"><%= description %></p>
     <% else %>
-      <p class="text-sm text-amber-600 mb-4">
+      <p class="text-sm text-slate-600 mb-4">
         少し疲れが出やすくなりそうな「考え方の癖」をそっとまとめました。
       </p>
     <% end %>
 
     <% if items.empty? %>
-      <div class="bg-amber-50 border border-amber-200 rounded-xl p-4 text-sm text-amber-700">
+      <div class="bg-amber-50 border border-amber-200 rounded-xl p-4 text-sm text-slate-700">
         データが不足しています（投稿が増えると表示されます）
       </div>
     <% else %>
@@ -54,11 +53,12 @@
         <% items.each_with_index do |item, idx| %>
           <li class="bg-slate-50 border border-amber-200 rounded-xl p-3">
             <div class="flex items-start gap-2">
-              <span class="inline-flex items-center justify-center w-6 h-6 rounded-full bg-amber-100 text-amber-800 text-xs font-extrabold">
+              <span class="inline-flex items-center justify-center w-6 h-6 rounded-full bg-amber-100 text-slate-800 text-xs font-extrabold">
                 <%= idx + 1 %>
               </span>
-              <p class="font-bold text-amber-900">
-                <%= item[:label] %>：<span class="font-semibold text-slate-700"><%= item[:short] %></span>
+              <p class="font-semibold text-slate-900">
+                <%= item[:label] %>：
+                <span class="font-semibold text-slate-700"><%= item[:short] %></span>
               </p>
             </div>
           </li>

--- a/app/views/analytics/_weekly_summary.html.erb
+++ b/app/views/analytics/_weekly_summary.html.erb
@@ -1,5 +1,4 @@
 <% category_label = local_assigns[:category_label].to_s %>
-
 <% total_posts_count = local_assigns[:total_posts_count].to_i %>
 
 <% this_week_posts_count = local_assigns[:this_week_posts_count].to_i %>
@@ -11,13 +10,13 @@
 <% last_week_top_word    = local_assigns[:last_week_top_word].presence %>
 
 <div class="border border-amber-100 bg-white p-4 rounded-2xl shadow-sm">
-  <p class="font-semibold mb-2">直近2週間のあなたの歩み</p>
+  <p class="font-semibold text-slate-900 mb-2">直近2週間のあなたの歩み</p>
 
-  <div class="text-sm text-amber-700 space-y-2">
+  <div class="text-sm text-slate-700 space-y-2">
     <div>
       合計：
       投稿数 <span class="font-semibold"><%= total_posts_count %>件</span>
-      <span class="text-amber-500">（<%= category_label %>）</span>
+      <span class="text-slate-500">（<%= category_label %>）</span>
     </div>
 
     <div>
@@ -27,14 +26,14 @@
       <% if this_week_mood_avg.present? %>
         <span class="font-semibold"><%= this_week_mood_avg %></span>
       <% else %>
-        <span class="text-amber-500">―</span>
+        <span class="text-slate-500">―</span>
       <% end %>
       /
       多い言葉
       <% if this_week_top_word.present? %>
         <span class="font-semibold">「<%= this_week_top_word %>」</span>
       <% else %>
-        <span class="text-amber-500">―</span>
+        <span class="text-slate-500">―</span>
       <% end %>
     </div>
 
@@ -45,14 +44,14 @@
       <% if last_week_mood_avg.present? %>
         <span class="font-semibold"><%= last_week_mood_avg %></span>
       <% else %>
-        <span class="text-amber-500">―</span>
+        <span class="text-slate-500">―</span>
       <% end %>
       /
       多い言葉
       <% if last_week_top_word.present? %>
         <span class="font-semibold">「<%= last_week_top_word %>」</span>
       <% else %>
-        <span class="text-amber-500">―</span>
+        <span class="text-slate-500">―</span>
       <% end %>
     </div>
   </div>

--- a/app/views/analytics/show.html.erb
+++ b/app/views/analytics/show.html.erb
@@ -12,9 +12,9 @@
 <%= render "category_tabs", category: @category, subcategory: @subcategory, top_subcategories: @top_subcategories %>
 
 <% if @analysis_data_insufficient %>
-  <div class="mt-4 rounded-2xl border border-amber-200 bg-white px-4 py-3 text-sm text-amber-700">
-    <p class="font-semibold">データが不足しています</p>
-    <p class="mt-1 text-xs text-amber-500">
+  <div class="mt-4 rounded-2xl border border-amber-200 bg-white px-4 py-3 text-sm text-slate-700">
+    <p class="font-semibold text-slate-900">データが不足しています</p>
+    <p class="mt-1 text-xs text-slate-500">
       このカテゴリの投稿がもう少し増えると、あなたらしさやヒントをより具体的に整理できます。
     </p>
   </div>


### PR DESCRIPTION
## 概要
本番で分析ページの本文テキストがオレンジ寄りに見えてしまうため、本文・補足文の文字色を slate 系に統一し、枠・リンクなどのアクセント（amber）は維持するよう調整しました。

## 変更内容
- 分析ページの部分テンプレートで本文/注釈の `text-amber-*` を `text-slate-*` に変更
- アクセントとしてのリンク色（`text-amber-700 hover:text-amber-900`）は維持

### 対象
- `app/views/analytics/_strength_top5.html.erb`
- `app/views/analytics/_weakness_top5.html.erb`
- `app/views/analytics/_tips_box.html.erb`
- `app/views/analytics/_weekly_summary.html.erb`

## 動作確認
- 分析ページを開き、各カードの本文が黒〜グレー（slate）で表示されること
- 「見る/閉じる」リンクなどアクセントはオレンジのままであること
- `rg -n "text-amber-(500|600|700)" app/views` の結果がリンク部分のみであること
