### PR TITLE
分析グラフの投稿数をmood入力有無ではなく全投稿で集計するよう修正

### DIFF
--- a/app/services/mood_trend_analyzer.rb
+++ b/app/services/mood_trend_analyzer.rb
@@ -11,7 +11,7 @@ class MoodTrendAnalyzer
 
     buckets = (0...days).map do |i|
       d = (start_date + i.days).to_date
-      [d, { posts: 0, scores: [] }]
+      [ d, { posts: 0, scores: [] } ]
     end.to_h
 
     scope = @user.posts.where(posted_at: start_date.beginning_of_day..end_date.end_of_day)


### PR DESCRIPTION
# 概要

分析ページの「気分のうつりかわりと投稿数（直近14日）」において、
投稿数（線グラフ）が mood 入力済み投稿のみをカウントしていたため、
実際の投稿件数とズレが発生していました。

本PRでは、投稿数を 全投稿（posted_at基準） で集計するよう修正しました。

# 修正内容

- MoodTrendAnalyzer の daily_points
- 投稿数を scores.size ではなく全投稿数でカウント
- 気分平均は従来通り mood入力済み投稿のみで算出
- グラフ説明文を以下に修正
- 面：気分の平均（入力がある日だけ） ／ 線：投稿数（全投稿）

# 変更前

- 投稿数 = mood入力済み投稿数
- mood未入力投稿はカウントされない

# 変更後

- 投稿数 = 全投稿数
- 気分平均 = mood入力済み投稿のみ

→ データ整合性とUXの向上

# 確認方法

- 過去日に遡って投稿（mood未入力含む）
- 分析ページを確認
- 線グラフが実際の投稿数と一致することを確認

# 影響範囲

- 分析ページ（AnalyticsController）
- MoodTrendAnalyzer