### PR TITLE
GA4にdominant_type計測を追加（診断完了・会話開始）

### DIFF
--- a/app/javascript/controllers/ga_event_controller.js
+++ b/app/javascript/controllers/ga_event_controller.js
@@ -3,7 +3,7 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static values = {
     name: String,
-    params: String, // JSON文字列（任意）
+    params: String,
   }
 
   connect() {
@@ -21,16 +21,29 @@ export default class extends Controller {
       return
     }
 
-    console.log("[GA]", name, params)
+    if (typeof gtag !== "function") {
+      console.log("[GA] gtag not ready", name, params)
+      this.element.remove()
+      return
+    }
 
-    if (typeof gtag === "function") {
+    // 追加：ユーザープロパティ設定
+    if (name === "set_user_properties") {
       if (params && Object.keys(params).length > 0) {
-        gtag("event", name, params)
+        gtag("set", "user_properties", params)
+        console.log("[GA] set user_properties", params)
       } else {
-        gtag("event", name)
+        console.log("[GA] skip set_user_properties (no params)")
       }
+      this.element.remove()
+      return
+    }
+
+    // 通常イベント
+    if (params && Object.keys(params).length > 0) {
+      gtag("event", name, params)
     } else {
-      console.log("gtag not ready")
+      gtag("event", name)
     }
 
     // 1回送ったら自分を消す（多重送信を抑える）

--- a/app/views/buddy_talks/topic.html.erb
+++ b/app/views/buddy_talks/topic.html.erb
@@ -1,5 +1,10 @@
 <% content_for :title, "バディと話す - AI-bloom" %>
 
+<% buddy = (user_signed_in? ? (current_user.buddy || Buddy.find_by(code: "normal")) : nil) %>
+<% dominant_type = (user_signed_in? ? current_user.dominant_type : nil) %>
+
+<div class="max-w-5xl mx-auto px-4 py-8">
+
   <div class="flex justify-center">
     <div class="inline-flex items-center gap-2">
       <h1 class="text-3xl font-extrabold tracking-wide text-slate-900">
@@ -23,6 +28,17 @@
   </div>
 
   <%= render "chat", buddy_talk: @post, messages: @messages %>
-</div>
 
-<%= render "composer", buddy_talk: @post %>
+  <%= render "composer", buddy_talk: @post %>
+
+  <%# ---- GA送信：会話開始（dominant_type + buddy_code） ---- %>
+  <% if user_signed_in? && dominant_type.present? && buddy.present? %>
+    <% params_json = json_escape({ dominant_type: dominant_type, buddy_code: buddy.code }.to_json) %>
+    <div
+      data-controller="ga-event"
+      data-ga-event-name-value="buddy_talk_started"
+      data-ga-event-params-value="<%= params_json %>">
+    </div>
+  <% end %>
+
+</div>

--- a/app/views/diagnoses/result_page.html.erb
+++ b/app/views/diagnoses/result_page.html.erb
@@ -177,12 +177,22 @@
     <% end %>
   </section>
 
-  <%# 診断結果を表示できた時だけ送る（1回だけ送信） %>
+  <%# ---- GA送信：結果が表示できた時だけ、1回だけ送る ---- %>
   <% if @current_type_info.present? %>
+    <% event_params_json = json_escape({ dominant_type: @dominant_type }.to_json) %>
+
+    <%# 1) 診断完了イベント（dominant_type を event param に乗せる） %>
     <div
       data-controller="ga-event"
       data-ga-event-name-value="diagnosis_completed"
-      data-ga-event-params-value='<%= { dominant_type: @dominant_type }.to_json %>'>
+      data-ga-event-params-value="<%= event_params_json %>">
+    </div>
+
+    <%# 2) ユーザープロパティにも dominant_type をセット（リピート/コホート用） %>
+    <div
+      data-controller="ga-event"
+      data-ga-event-name-value="set_user_properties"
+      data-ga-event-params-value="<%= event_params_json %>">
     </div>
   <% end %>
 


### PR DESCRIPTION
■ 概要
診断→会話の移行率やタイプ別リピート率分析のため、
GA4へ dominant_type を送信する実装を追加しました。

■ 追加内容
・diagnosis_completed イベント送信
・buddy_talk_started イベント送信
・dominant_type をイベントパラメータとして送信
・dominant_type をユーザープロパティとしても設定
・Stimulusのga-eventコントローラーを整理
・JSONエスケープ対応（htmlエスケープ対策）

■ 目的
今後以下の分析を可能にするため
・dominant_type別 診断→会話移行率
・タイプ別リピート率
・バディ別利用回数

■ 確認方法（本番）
1. 本番で診断実行
2. GAリアルタイムで diagnosis_completed を確認
3. パラメータ dominant_type が表示されること
4. バディ画面表示で buddy_talk_started を確認
