### PR TITLE
GA4: dominant_type を user_property 化して診断→会話分析を安定化

### DIFF
--- a/app/javascript/controllers/ga_event_controller.js
+++ b/app/javascript/controllers/ga_event_controller.js
@@ -10,11 +10,9 @@ export default class extends Controller {
     const name = this.nameValue
     const params = this.parseParams(this.paramsValue)
 
-    // layout から <html data-env="..."> を渡す前提
     const env = document.documentElement.dataset.env || "unknown"
     const isProd = env === "production"
 
-    // 開発ではGAに送らず、consoleで発火確認だけする（GA汚染防止）
     if (!isProd) {
       console.log("[GA DEV]", name, params)
       this.element.remove()
@@ -27,13 +25,10 @@ export default class extends Controller {
       return
     }
 
-    // 追加：ユーザープロパティ設定
+    // user_property セット（永続化）
     if (name === "set_user_properties") {
       if (params && Object.keys(params).length > 0) {
         gtag("set", "user_properties", params)
-        console.log("[GA] set user_properties", params)
-      } else {
-        console.log("[GA] skip set_user_properties (no params)")
       }
       this.element.remove()
       return
@@ -46,7 +41,6 @@ export default class extends Controller {
       gtag("event", name)
     }
 
-    // 1回送ったら自分を消す（多重送信を抑える）
     this.element.remove()
   }
 

--- a/app/views/buddy_talks/start.turbo_stream.erb
+++ b/app/views/buddy_talks/start.turbo_stream.erb
@@ -8,9 +8,11 @@
 
 <turbo-stream action="append" target="ga-tracker">
   <template>
+    <% event_params_json = json_escape({ dominant_type: (user_signed_in? ? current_user.dominant_type : nil) }.compact.to_json) %>
     <div
       data-controller="ga-event"
-      data-ga-event-name-value="buddy_talk_created">
+      data-ga-event-name-value="buddy_talk_created"
+      data-ga-event-params-value="<%= event_params_json %>">
     </div>
   </template>
 </turbo-stream>

--- a/app/views/diagnoses/result_page.html.erb
+++ b/app/views/diagnoses/result_page.html.erb
@@ -181,17 +181,17 @@
   <% if @current_type_info.present? %>
     <% event_params_json = json_escape({ dominant_type: @dominant_type }.to_json) %>
 
-    <%# 1) 診断完了イベント（dominant_type を event param に乗せる） %>
-    <div
-      data-controller="ga-event"
-      data-ga-event-name-value="diagnosis_completed"
-      data-ga-event-params-value="<%= event_params_json %>">
-    </div>
-
-    <%# 2) ユーザープロパティにも dominant_type をセット（リピート/コホート用） %>
+    <%# 1) user_property を先にセット（以降のイベントでタイプが効くようにする） %>
     <div
       data-controller="ga-event"
       data-ga-event-name-value="set_user_properties"
+      data-ga-event-params-value="<%= event_params_json %>">
+    </div>
+
+    <%# 2) 診断完了イベント（dominant_type を event param にも乗せる） %>
+    <div
+      data-controller="ga-event"
+      data-ga-event-name-value="diagnosis_completed"
       data-ga-event-params-value="<%= event_params_json %>">
     </div>
   <% end %>


### PR DESCRIPTION
# 概要

- 診断完了時に dominant_type を user_property としてセットし、後続イベントでもタイプ別に分析できるようにしました

- buddy_talk_created にも dominant_type をイベントパラメータとして付与し、(not set) 混入を抑制しました

# 変更点

- ga-event stimulus に set_user_properties 対応を追加
- 診断結果ページで set_user_properties を送信
- 会話開始イベント（buddy_talk_created）に dominant_type パラメータを付与

# 確認方法

- 本番環境で診断を1回実施
- GA4 リアルタイム → イベント diagnosis_completed が発火し dominant_type が表示される
- 同ユーザーで会話開始 → buddy_talk_created が発火し dominant_type が表示される
- Explorations で dominant_type によるセグメント/比較が (not set) だらけにならないことを確認