### PR TITLE
Googleログイン時のnickname必須バリデーションで失敗する不具合を修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,11 +17,20 @@ class User < ApplicationRecord
       email_user = find_by(email: auth.info.email)
       if email_user
         email_user.update!(provider: auth.provider, uid: auth.uid)
+
+        # nicknameが空だった時の保険（過去データ対策）
+        if email_user.nickname.blank?
+          email_user.update!(nickname: build_nickname_from_auth(auth))
+        end
+
         return email_user
       end
     end
 
     user.email = auth.info.email if user.email.blank?
+
+    # nickname 必須対策（Googleログインでも必ず入るようにする）
+    user.nickname = build_nickname_from_auth(auth) if user.nickname.blank?
 
     # password必須バリデーション回避（validatable前提）
     user.password = Devise.friendly_token[0, 20] if user.encrypted_password.blank?
@@ -29,6 +38,13 @@ class User < ApplicationRecord
     user.save!
     user
   end
+
+  def self.build_nickname_from_auth(auth)
+    auth.info.name.presence ||
+      auth.info.email.to_s.split("@").first.presence ||
+      "user_#{SecureRandom.hex(4)}"
+  end
+  private_class_method :build_nickname_from_auth
 
   # -------------------------------------------------------
   # アソシエーション


### PR DESCRIPTION
# 概要

Google OAuthログイン時、User.nickname が未設定のまま保存されようとしてバリデーションで失敗していたため、OmniAuth情報から nickname を自動補完するよう修正。

# 変更点

- User.from_omniauth で nickname を auth.info.name → emailの@前 → ランダム の優先順で補完
- 既存メールユーザーをGoogle連携へ寄せるケースでも nickname が空なら補完

# 確認

- 新規Googleログインでユーザー作成・ログインできること
- 既存メールユーザーでGoogleログインしても連携されること