### PR TITLE
デプロイエラーの修正

### DIFF
--- a/db/migrate/20260217182644_add_confirmable_columns_to_users.rb
+++ b/db/migrate/20260217182644_add_confirmable_columns_to_users.rb
@@ -1,0 +1,10 @@
+class AddConfirmableColumnsToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :confirmation_token,   :string,   if_not_exists: true
+    add_column :users, :confirmed_at,         :datetime, if_not_exists: true
+    add_column :users, :confirmation_sent_at, :datetime, if_not_exists: true
+    add_column :users, :unconfirmed_email,    :string,   if_not_exists: true
+
+    add_index  :users, :confirmation_token, unique: true, if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_17_144420) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_17_182644) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 


### PR DESCRIPTION
## 概要

本番環境にて `confirmed_at` が存在しないことによる
`undefined local variable or method 'confirmed_at'` エラー（500）が発生していたため、
不足していた Devise confirmable 用カラムを追加しました。

## 背景

- migration `Add confirmable to users` は up になっていた
- しかし本番DBに confirmable カラムが実際には存在していなかった
- TopControllerで `confirmed_at` を参照しており 500 エラーが発生

## 対応内容

users テーブルに以下カラムを追加：

- confirmation_token
- confirmed_at
- confirmation_sent_at
- unconfirmed_email

加えて：
- confirmation_token に unique index を追加
- `if_not_exists: true` を使用し安全に追加

## 確認方法

```bash
bin/rails runner "p User.column_names.grep(/confirm/)"
