### PR TITLE
本番500エラー修正（PromptRepository互換対応）

### DIFF
--- a/app/services/ai/prompt_repository.rb
+++ b/app/services/ai/prompt_repository.rb
@@ -5,61 +5,70 @@ module Ai
     CONFIG_PATH = Rails.root.join("config", "ai", "prompts.yml")
     DEFAULT_LOCALE = :ja
 
-    def self.config
-      @config ||= YAML.load_file(CONFIG_PATH, aliases: true).deep_symbolize_keys
-    end
+    class << self
+      def config
+        @config ||= YAML.load_file(CONFIG_PATH, aliases: true).deep_symbolize_keys
+      end
 
-    def self.base_system(locale: DEFAULT_LOCALE)
-      config.fetch(locale.to_sym).dig(:base, :system).to_s
-    end
+      def base_system(locale: DEFAULT_LOCALE)
+        config.fetch(locale.to_sym).dig(:base, :system).to_s
+      end
 
-    def self.system_for(type:, user_nickname: nil, buddy: nil, locale: DEFAULT_LOCALE)
-      cfg = config.fetch(locale.to_sym)
+      def system_for(type:, user_nickname: nil, buddy: nil, locale: DEFAULT_LOCALE)
+        cfg = config.fetch(locale.to_sym)
 
-      base = cfg.dig(:base, :system).to_s
+        base = cfg.dig(:base, :system).to_s
 
-      nickname   = user_nickname.presence || "あなた"
-      buddy_name = buddy&.respond_to?(:name) && buddy.name.present? ? buddy.name : "バディ"
+        nickname   = user_nickname.presence || "あなた"
+        buddy_name = buddy&.respond_to?(:name) && buddy.name.present? ? buddy.name : "バディ"
 
-      buddy_system =
-        if buddy&.respond_to?(:persona_prompt) && buddy.persona_prompt.present?
-          buddy.persona_prompt.to_s
-        else
+        buddy_system =
+          if buddy&.respond_to?(:persona_prompt) && buddy.persona_prompt.present?
+            buddy.persona_prompt.to_s
+          else
+            ""
+          end
+
+        type_key = type.to_s.downcase.to_sym
+        type_system =
+          cfg.dig(type_key, :system).to_s.presence ||
+          cfg.dig(:default, :system).to_s.presence ||
           ""
-        end
 
-      type_key = type.to_s.downcase.to_sym
-      type_system =
-        cfg.dig(type_key, :system).to_s.presence ||
-        cfg.dig(:default, :system).to_s.presence ||
-        ""
+        merged =
+          if buddy_system.present?
+            "#{base}\n\n#{buddy_system}"
+          elsif type_system.present?
+            "#{base}\n\n#{type_system}"
+          else
+            base
+          end
 
-      merged =
-        if buddy_system.present?
-          "#{base}\n\n#{buddy_system}"
-        elsif type_system.present?
-          "#{base}\n\n#{type_system}"
-        else
-          base
-        end
+        system = format(
+          merged,
+          user_nickname: nickname,
+          buddy_name: buddy_name
+        )
 
-      system = format(
-        merged,
-        user_nickname: nickname,
-        buddy_name: buddy_name
-      )
+        { system: system }
+      rescue KeyError => e
+        Rails.logger.warn("[PromptRepository] system_for failed: #{e.class} #{e.message}")
+        { system: merged.to_s }
+      rescue => e
+        Rails.logger.error("[PromptRepository] system_for error: #{e.class} #{e.message}")
+        { system: "" }
+      end
 
-      { system: system }
-    rescue KeyError => e
-      Rails.logger.warn("[PromptRepository] format failed: #{e.message}")
-      { system: merged }
-    end
+      def for(type, user_nickname: nil, buddy: nil, locale: DEFAULT_LOCALE)
+        system_for(type: type, user_nickname: user_nickname, buddy: buddy, locale: locale)
+      end
 
-    def self.user_template_for(key:, locale: DEFAULT_LOCALE)
-      cfg = config.fetch(locale.to_sym)
-      template = cfg.dig(key.to_sym, :user).to_s
-      raise KeyError, "User prompt template not found: #{key}" if template.blank?
-      template
+      def user_template_for(key:, locale: DEFAULT_LOCALE)
+        cfg = config.fetch(locale.to_sym)
+        template = cfg.dig(key.to_sym, :user).to_s
+        raise KeyError, "User prompt template not found: #{key}" if template.blank?
+        template
+      end
     end
   end
 end


### PR DESCRIPTION
# 発生事象
非同期化後、本番環境にて以下の500エラー発生
NoMethodError: undefined method `for' for Ai::PromptRepository
DeepDive系Job内で旧API .for が呼ばれていたことが原因。

# 対応内容
## ① 互換メソッド追加
PromptRepository.for を復活し、system_forへ委譲
```
def self.for(type, user_nickname: nil, buddy: nil, locale: DEFAULT_LOCALE)
  system_for(type: type, user_nickname: user_nickname, buddy: buddy, locale: locale)
end
```
## ② 例外フォールバック強化
- KeyError時ログ出力
- 想定外エラー時もsystem空文字返却

# 影響範囲
- DeepDiveJob
- PraiseSummaryJob
- 既存非同期AI系処理

# 確認結果
- 新規投稿：正常動作
- 返信：正常動作
- 深掘り：正常動作
- やさしくまとめる：正常動作
- 本番環境500解消