### PR TITLE
バディトークのmessages描画エラー修正（Turbo差し替え時のNameError解消）

### DIFF
--- a/app/controllers/buddy_talks_controller.rb
+++ b/app/controllers/buddy_talks_controller.rb
@@ -219,7 +219,7 @@ class BuddyTalksController < ApplicationController
           turbo_stream.replace(
             "messages",
             partial: "buddy_talks/messages",
-            locals: { messages: @messages, buddy: buddy }
+            locals: { messages: @messages, buddy: buddy, buddy_talk: @buddy_talk }
           ),
 
           # append は messages_list に統一

--- a/app/javascript/poll_ai_reply.js
+++ b/app/javascript/poll_ai_reply.js
@@ -1,9 +1,13 @@
-document.addEventListener("turbo:load", () => {
-  const container = document.querySelector("[data-ai-polling-post-id]");
-  if (!container) return;
+function startPollingIfNeeded() {
+  const el = document.querySelector("[data-ai-polling-post-id]");
+  if (!el) return;
 
-  const postId = container.dataset.aiPollingPostId;
+  const postId = el.dataset.aiPollingPostId;
   if (!postId) return;
+
+  // 二重起動防止
+  if (el.dataset.aiPollingStarted === "1") return;
+  el.dataset.aiPollingStarted = "1";
 
   let attempts = 0;
   const maxAttempts = 40; // 約2分
@@ -13,22 +17,25 @@ document.addEventListener("turbo:load", () => {
     attempts++;
 
     try {
-      const res = await fetch(`/buddy_talks/${postId}/ai_status`);
+      const res = await fetch(`/buddy_talks/${postId}/ai_status`, {
+        headers: { Accept: "application/json" }
+      });
       if (!res.ok) return;
 
       const data = await res.json();
 
       if (data.completed) {
         clearInterval(timer);
-        Turbo.visit(window.location.href);
+        Turbo.visit(window.location.href, { action: "replace" });
       }
 
-      if (attempts >= maxAttempts) {
-        clearInterval(timer);
-      }
-
+      if (attempts >= maxAttempts) clearInterval(timer);
     } catch (_) {
       if (attempts >= maxAttempts) clearInterval(timer);
     }
   }, interval);
-});
+}
+
+document.addEventListener("turbo:load", startPollingIfNeeded);
+document.addEventListener("turbo:render", startPollingIfNeeded);
+document.addEventListener("turbo:frame-load", startPollingIfNeeded);

--- a/app/views/buddy_talks/_chat.html.erb
+++ b/app/views/buddy_talks/_chat.html.erb
@@ -1,9 +1,3 @@
-<%= turbo_frame_tag "messages" do %>
-  <div id="messages_list"
-       class="space-y-4 px-2 sm:px-4"
-       data-ai-polling-post-id="<%= @buddy_talk&.id %>">
-
-    <%= render "messages", messages: messages, buddy: buddy %>
-
-  </div>
-<% end %>
+<div class="space-y-4 px-2 sm:px-4">
+  <%= render "messages", messages: messages, buddy: buddy, buddy_talk: @buddy_talk %>
+</div>

--- a/app/views/buddy_talks/_messages.html.erb
+++ b/app/views/buddy_talks/_messages.html.erb
@@ -1,5 +1,9 @@
 <%= turbo_frame_tag "messages" do %>
-  <div id="messages_list" class="space-y-4 px-2 sm:px-4">
+  <% talk = local_assigns[:buddy_talk] || @buddy_talk %>
+
+  <div id="messages_list"
+       class="space-y-4"
+       data-ai-polling-post-id="<%= talk&.id %>">
     <% messages.each do |message| %>
       <%= render "message", message: message, buddy: buddy %>
     <% end %>


### PR DESCRIPTION
## 概要
バディトークの「送信」「一緒に振り返る」「やさしくまとめる」実行時に、
`_messages.html.erb` 内で `buddy_talk` が未定義となり NameError が発生していた問題を修正しました。

## 原因
Turbo Stream による `replace("messages")` 実行時に、
partialへ `buddy_talk` が locals として渡されていなかったため、
view内で `buddy_talk` を参照した際にエラーが発生していました。

## 対応内容
- `_messages.html.erb` で `local_assigns` を考慮し安全に参照するよう修正
- Turbo差し替え後でもポーリングが継続する構造を維持

## 確認
- 送信・振り返り・まとめ実行時にエラーが発生しないこと
- AI返信が非同期で生成され、自動更新されること
