### PR TITLE
バディトーク：AI返信ポーリング安定化（新規投稿でも自動反映）

### DIFF
--- a/app/controllers/buddy_talks_controller.rb
+++ b/app/controllers/buddy_talks_controller.rb
@@ -34,6 +34,11 @@ class BuddyTalksController < ApplicationController
 
       # ---- 非同期：AI返信生成（ここでは待たない）----
       @placeholder_id = build_placeholder_id
+
+      # ポーリング開始時刻を記録（この時刻以降に生成されたAiMessageがあればcompleted）
+      session[:ai_polling_started_at] ||= {}
+      session[:ai_polling_started_at][@post.id.to_s] = Time.zone.now.iso8601
+
       Ai::GenerateBuddyReplyJob.perform_later(
         post_id: @post.id,
         user_id: current_user.id,
@@ -64,7 +69,7 @@ class BuddyTalksController < ApplicationController
               locals: { buddy_talk: @buddy_talk }
             ),
 
-            # ここから append は messages_list に統一
+            # append は messages_list に統一
             turbo_stream.append(
               "messages_list",
               partial: "buddy_talks/system_notice",
@@ -82,6 +87,8 @@ class BuddyTalksController < ApplicationController
             )
           ]
         end
+
+        # start は redirect で topic に飛ぶため、topic側で pending 表示を出せるよう created=1 を付ける
         format.html { redirect_to buddy_talk_topic_path(@buddy_talk, created: 1) }
       end
     else
@@ -102,6 +109,13 @@ class BuddyTalksController < ApplicationController
     session[:buddy_talk_post_id] = @buddy_talk.id
     @messages = build_timeline(@buddy_talk)
     @buddy    = @buddy_talk.buddy || current_buddy_fallback
+
+    # created=1 の初回表示で「まだAI返信が無い」なら pending を表示するフラグを立てる
+    if params[:created].present?
+      has_ai = @messages.any? { |m| m.is_a?(AiMessage) }
+      @show_initial_pending = !has_ai
+    end
+
     render :show
   end
 
@@ -115,6 +129,11 @@ class BuddyTalksController < ApplicationController
 
     # ---- 非同期：AI返信生成（ここでは待たない）----
     @placeholder_id = build_placeholder_id
+
+    # ポーリング開始時刻を記録（この時刻以降に生成されたAiMessageがあればcompleted）
+    session[:ai_polling_started_at] ||= {}
+    session[:ai_polling_started_at][@buddy_talk.id.to_s] = Time.zone.now.iso8601
+
     Ai::GenerateBuddyReplyJob.perform_later(
       post_id: @buddy_talk.id,
       user_id: current_user.id,
@@ -141,6 +160,11 @@ class BuddyTalksController < ApplicationController
     buddy = @buddy_talk.buddy || current_buddy_fallback
 
     @placeholder_id = build_placeholder_id
+
+    # ポーリング開始時刻を記録
+    session[:ai_polling_started_at] ||= {}
+    session[:ai_polling_started_at][@buddy_talk.id.to_s] = Time.zone.now.iso8601
+
     Ai::GenerateDeepDiveJob.perform_later(
       post_id: @buddy_talk.id,
       user_id: current_user.id,
@@ -167,6 +191,11 @@ class BuddyTalksController < ApplicationController
     buddy = @buddy_talk.buddy || current_buddy_fallback
 
     @placeholder_id = build_placeholder_id
+
+    # ポーリング開始時刻を記録
+    session[:ai_polling_started_at] ||= {}
+    session[:ai_polling_started_at][@buddy_talk.id.to_s] = Time.zone.now.iso8601
+
     Ai::GeneratePraiseSummaryJob.perform_later(
       post_id: @buddy_talk.id,
       user_id: current_user.id,
@@ -184,6 +213,11 @@ class BuddyTalksController < ApplicationController
     buddy = @buddy_talk.buddy || current_buddy_fallback
 
     @placeholder_id = build_placeholder_id
+
+    # ポーリング開始時刻を記録
+    session[:ai_polling_started_at] ||= {}
+    session[:ai_polling_started_at][@buddy_talk.id.to_s] = Time.zone.now.iso8601
+
     Ai::GenerateSelfPrSummaryJob.perform_later(
       post_id: @buddy_talk.id,
       user_id: current_user.id,
@@ -205,6 +239,27 @@ class BuddyTalksController < ApplicationController
   def close
     session.delete(:buddy_talk_post_id)
     redirect_to posts_path
+  end
+
+  # ポーリング用：AI生成完了確認
+  def ai_status
+    post = current_user.posts.find(params[:id])
+
+    # ポーリング開始時刻（なければ post更新時刻を基準にする）
+    started_at =
+      begin
+        t = session.dig(:ai_polling_started_at, post.id.to_s)
+        t.present? ? Time.zone.parse(t) : nil
+      rescue
+        nil
+      end
+
+    started_at ||= post.updated_at || post.created_at
+
+    # 「開始時刻以降」に生成されたAIメッセージがあるかで判定
+    ai_completed = AiMessage.where(post: post).where("created_at >= ?", started_at).exists?
+
+    render json: { completed: ai_completed }
   end
 
   private
@@ -287,14 +342,5 @@ class BuddyTalksController < ApplicationController
 
   def current_buddy_fallback
     current_user.buddy || Buddy.find_by(code: "normal")
-  end
-
-  def ai_status
-    post = current_user.posts.find(params[:id])
-
-    # pendingプレースホルダが消えていたら＝AI返信完了とみなす
-    ai_completed = AiMessage.where(post: post).exists?
-
-    render json: { completed: ai_completed }
   end
 end

--- a/app/javascript/poll_ai_reply.js
+++ b/app/javascript/poll_ai_reply.js
@@ -1,41 +1,135 @@
-function startPollingIfNeeded() {
-  const el = document.querySelector("[data-ai-polling-post-id]");
-  if (!el) return;
+(() => {
+  // postId -> { attempts, timerId }
+  const pollingState = new Map();
 
-  const postId = el.dataset.aiPollingPostId;
-  if (!postId) return;
+  function findMessagesList() {
+    // 最優先：idで拾う（あなたのHTMLに合わせる）
+    return document.querySelector("#messages_list[data-ai-polling-post-id]") ||
+      document.querySelector("[data-ai-polling-post-id]");
+  }
 
-  // 二重起動防止
-  if (el.dataset.aiPollingStarted === "1") return;
-  el.dataset.aiPollingStarted = "1";
+  function getPostId(el) {
+    const v = el?.dataset?.aiPollingPostId;
+    if (!v) return null;
+    if (!/^\d+$/.test(v)) return null;
+    return v;
+  }
 
-  let attempts = 0;
-  const maxAttempts = 40; // 約2分
-  const interval = 3000;
+  function getStatusUrl(el, postId) {
+    const explicit = el?.dataset?.aiStatusUrl;
+    if (explicit && explicit.startsWith("/")) return explicit;
+    return `/buddy_talks/${postId}/ai_status`;
+  }
 
-  const timer = setInterval(async () => {
-    attempts++;
+  // 「考え中（pending）」があるときだけポーリングする
+  function hasPending(el) {
+    if (!el) return false;
+
+    // pending partialが placeholder_id をDOM idとして持ってる想定（ai_pending_xxx）
+    // どちらでも拾えるように複数条件で検出
+    return !!(
+      el.querySelector('[id^="ai_pending_"]') ||
+      el.querySelector("[data-ai-pending='1']") ||
+      el.querySelector(".js-ai-pending") ||
+      // テキスト検知（最後の保険。文言変えたら効かないので保険扱い）
+      (el.textContent && el.textContent.includes("バディが考え中"))
+    );
+  }
+
+  function stop(postId) {
+    const st = pollingState.get(postId);
+    if (!st) return;
+    if (st.timerId) clearInterval(st.timerId);
+    pollingState.delete(postId);
+  }
+
+  async function pollOnce(el, postId) {
+    const st = pollingState.get(postId);
+    if (!st) return;
+
+    // pending が消えたなら（＝表示上もう待ってない）ポーリング停止
+    if (!hasPending(el)) {
+      stop(postId);
+      return;
+    }
+
+    st.attempts += 1;
+
+    const maxAttempts = 60; // 約3分（初回投稿は長めにしとく）
+    const url = getStatusUrl(el, postId);
+    if (!url) {
+      stop(postId);
+      return;
+    }
 
     try {
-      const res = await fetch(`/buddy_talks/${postId}/ai_status`, {
-        headers: { Accept: "application/json" }
+      const res = await fetch(url, {
+        headers: { Accept: "application/json" },
+        credentials: "same-origin"
       });
-      if (!res.ok) return;
+
+      // 404/401 など致命は即停止（エラー増殖防止）
+      if (!res.ok) {
+        if ([401, 403, 404, 422, 500].includes(res.status) || st.attempts >= maxAttempts) {
+          stop(postId);
+        }
+        return;
+      }
 
       const data = await res.json();
 
-      if (data.completed) {
-        clearInterval(timer);
-        Turbo.visit(window.location.href, { action: "replace" });
+      if (data?.completed) {
+        stop(postId);
+
+        // Turboがいるならreplaceで同URL再訪問して最新メッセージを再描画
+        if (window.Turbo) {
+          Turbo.visit(window.location.href, { action: "replace" });
+        } else {
+          window.location.reload();
+        }
+        return;
       }
 
-      if (attempts >= maxAttempts) clearInterval(timer);
+      if (st.attempts >= maxAttempts) stop(postId);
     } catch (_) {
-      if (attempts >= maxAttempts) clearInterval(timer);
+      if (st.attempts >= maxAttempts) stop(postId);
     }
-  }, interval);
-}
+  }
 
-document.addEventListener("turbo:load", startPollingIfNeeded);
-document.addEventListener("turbo:render", startPollingIfNeeded);
-document.addEventListener("turbo:frame-load", startPollingIfNeeded);
+  function startIfNeeded() {
+    const el = findMessagesList();
+    if (!el) return;
+
+    const postId = getPostId(el);
+    if (!postId) return;
+
+    // pendingが無いなら起動しない（無限叩きを防ぐ）
+    if (!hasPending(el)) return;
+
+    if (pollingState.has(postId)) return;
+
+    const st = { attempts: 0, timerId: null };
+    pollingState.set(postId, st);
+
+    const interval = 3000;
+    st.timerId = setInterval(() => pollOnce(el, postId), interval);
+
+    // 初回即実行（体感改善）
+    pollOnce(el, postId);
+  }
+
+  // Turboのキャッシュに入る前に停止（戻る/進むでタイマー残留しがち）
+  document.addEventListener("turbo:before-cache", () => {
+    for (const postId of pollingState.keys()) stop(postId);
+  });
+
+  // 初回ロード & Turbo遷移
+  document.addEventListener("DOMContentLoaded", startIfNeeded);
+  document.addEventListener("turbo:load", startIfNeeded);
+  document.addEventListener("turbo:render", startIfNeeded);
+  document.addEventListener("turbo:frame-load", startIfNeeded);
+
+  // DOMに pending が append された瞬間も拾う（startのturbo_streamやreply後）
+  const observer = new MutationObserver(() => startIfNeeded());
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+})();

--- a/app/views/buddy_talks/_chat.html.erb
+++ b/app/views/buddy_talks/_chat.html.erb
@@ -1,3 +1,7 @@
 <div class="space-y-4 px-2 sm:px-4">
   <%= render "messages", messages: messages, buddy: buddy, buddy_talk: @buddy_talk %>
 </div>
+
+<% if @show_initial_pending %>
+  <%= render "buddy_talks/pending_ai", placeholder_id: "initial_pending" %>
+<% end %>

--- a/app/views/buddy_talks/_messages.html.erb
+++ b/app/views/buddy_talks/_messages.html.erb
@@ -1,9 +1,17 @@
 <%= turbo_frame_tag "messages" do %>
   <% talk = local_assigns[:buddy_talk] || @buddy_talk %>
 
+  <% active =
+       @show_initial_pending ||
+       (defined?(@placeholder_id) && @placeholder_id.present?) ||
+       (defined?(placeholder_id) && placeholder_id.present?)
+  %>
+
   <div id="messages_list"
-       class="space-y-4"
-       data-ai-polling-post-id="<%= talk&.id %>">
+       class="space-y-4 px-2 sm:px-4"
+       data-ai-polling-post-id="<%= talk&.id %>"
+       data-ai-status-url="<%= talk.present? ? buddy_talk_ai_status_path(talk) : "" %>"
+       data-ai-polling-active="<%= active ? 1 : 0 %>">
     <% messages.each do |message| %>
       <%= render "message", message: message, buddy: buddy %>
     <% end %>

--- a/app/views/buddy_talks/_meta_form.html.erb
+++ b/app/views/buddy_talks/_meta_form.html.erb
@@ -1,7 +1,7 @@
 <section class="bg-white rounded-3xl border border-amber-100 shadow-sm p-6 space-y-5">
   <h2 class="text-lg font-bold text-center text-slate-800">今日のお話のはじまり</h2>
 
-  <%= form_with model: post, url: start_buddy_talk_path, data: { turbo: false }, class: "space-y-4" do |f| %>
+  <%= form_with model: post, url: start_buddy_talk_path, class: "space-y-4" do |f| %>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-1">
       <div>
         <%= f.label :posted_at, "日付", class: "block text-xs font-semibold text-slate-700 mb-1" %>


### PR DESCRIPTION
# 修正内容
- AI返信ポーリングを pending検知型へ変更
- 新規投稿直後でもリロード不要で自動更新
- Turbo差し替え後にもポーリング開始するよう調整
- 無限リクエスト発生を防止

# 背景
新規投稿直後のみAI返信が自動反映されず、
リロードが必要になる問題が発生していたため。

# 確認
- 新規投稿後に自動でAI返信が表示されること
- 返信後にポーリングが停止すること
- 404増殖が発生しないこと