### PR TITLE
nilガードの簡略化とガード節への整理

### DIFF
--- a/app/controllers/buddy_talks_controller.rb
+++ b/app/controllers/buddy_talks_controller.rb
@@ -10,7 +10,7 @@ class BuddyTalksController < ApplicationController
   def show
     @post = Post.new(posted_at: Time.zone.now)
 
-    if @buddy_talk.present?
+    if @buddy_talk
       @messages = build_timeline(@buddy_talk)
       @buddy = @buddy_talk.buddy || current_buddy_fallback
     else
@@ -254,10 +254,10 @@ class BuddyTalksController < ApplicationController
 
   def set_current_buddy_talk
     id = params[:id].presence || session[:buddy_talk_post_id]
-    return if id.blank?
+    return unless id
 
     @buddy_talk = current_user.posts.find_by(id: id)
-    session[:buddy_talk_post_id] = @buddy_talk.id if @buddy_talk.present?
+    session[:buddy_talk_post_id] = @buddy_talk.id if @buddy_talk
   end
 
   def set_topic_buddy_talk

--- a/app/jobs/ai/generate_buddy_reply_job.rb
+++ b/app/jobs/ai/generate_buddy_reply_job.rb
@@ -25,7 +25,7 @@ module Ai
       )
 
       # 4) 返信が作れなかった場合のフォールバック（表示だけはする）
-      if ai_message.blank?
+      unless ai_message
         ai_message = AiMessage.create!(
           user: user,
           buddy: buddy,

--- a/app/jobs/ai/generate_deep_dive_job.rb
+++ b/app/jobs/ai/generate_deep_dive_job.rb
@@ -18,7 +18,7 @@ module Ai
                  .order(created_at: :desc)
                  .first
 
-      if ai_message.blank?
+      unless ai_message
         ai_message = AiMessage.create!(
           user: user,
           buddy: buddy,

--- a/app/jobs/ai/generate_praise_summary_job.rb
+++ b/app/jobs/ai/generate_praise_summary_job.rb
@@ -18,7 +18,7 @@ module Ai
                  .order(created_at: :desc)
                  .first
 
-      if ai_message.blank?
+      unless ai_message
         ai_message = AiMessage.create!(
           user: user,
           buddy: buddy,

--- a/app/jobs/ai/generate_self_pr_summary_job.rb
+++ b/app/jobs/ai/generate_self_pr_summary_job.rb
@@ -18,7 +18,7 @@ module Ai
                  .order(created_at: :desc)
                  .first
 
-      if ai_message.blank?
+      unless ai_message
         ai_message = AiMessage.create!(
           user: user,
           buddy: buddy,


### PR DESCRIPTION
## 概要
nilチェックの書き方を見直し、シンプルで読みやすい条件分岐に整理しました。

## 変更内容
- present? をシンプルな truthy チェックへ置き換え
- blank? の一部をガード節へ変更
- AccountSettingsControllerの条件分岐整理

## 目的
- 可読性向上
- 条件分岐の意図を明確にする
- 軽微なリファクタリング

## 確認事項
- 既存の挙動が変わっていないこと
- rspec / rubocop が通ること